### PR TITLE
Fix unused id variable in ClientForm

### DIFF
--- a/src/components/Clients/ClientForm/ClientForm.jsx
+++ b/src/components/Clients/ClientForm/ClientForm.jsx
@@ -170,7 +170,7 @@ const ClientForm = () => {
         observacao: formData.observacao,
         status: 'ATIVO',
         // Envia a lista de responsaveis (removendo o ID temporário do frontend)
-        responsaveis: contacts.map(({ id, ...rest }) => rest)
+        responsaveis: contacts.map(({ id: _discard, ...rest }) => rest)
     };
 
     try {


### PR DESCRIPTION
## Summary
- rename `id` destructuring variable to `_discard` when mapping contacts

## Testing
- `npm run lint` *(fails: numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68899917c760833096099d22af3456d9